### PR TITLE
[test] fix focus and strict effects related

### DIFF
--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -131,7 +131,7 @@ describe('<TreeView />', () => {
     });
   });
 
-  it('should call onKeyDown when a key is pressed', () => {
+  it('should call onKeyDown when a key is pressed', async () => {
     const handleKeyDown = spy();
 
     const { getByRole } = render(
@@ -142,6 +142,7 @@ describe('<TreeView />', () => {
     act(() => {
       getByRole('tree').focus();
     });
+    await null;
 
     fireEvent.keyDown(getByRole('tree'), { key: 'Enter' });
     fireEvent.keyDown(getByRole('tree'), { key: 'A' });
@@ -338,7 +339,7 @@ describe('<TreeView />', () => {
     expect(queryByText('test')).to.equal(null);
   });
 
-  it('should work in a portal', () => {
+  it('should work in a portal', async () => {
     const { getByRole, getByTestId } = render(
       <Portal>
         <TreeView id="tree">
@@ -353,6 +354,7 @@ describe('<TreeView />', () => {
     act(() => {
       getByRole('tree').focus();
     });
+    await null;
     fireEvent.keyDown(getByRole('tree'), { key: 'ArrowDown' });
 
     expect(getByTestId('two')).toHaveVirtualFocus();

--- a/packages/material-ui-private-theming/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-private-theming/src/ThemeProvider/ThemeProvider.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createClientRender } from 'test/utils';
+import { createClientRender, RenderCounter } from 'test/utils';
 import useTheme from '../useTheme';
 import ThemeProvider from './ThemeProvider';
 
@@ -49,25 +49,18 @@ describe('ThemeProvider', () => {
   });
 
   it('should memoize the merged output', () => {
-    const themes = [];
-
     const ref = React.createRef();
+    const getRenderCountRef = React.createRef();
     const text = () => ref.current.textContent;
     function Test() {
       const theme = useTheme();
-      const themeRef = React.useRef(); // needed due to double-invokes effect in StrictMode
-      React.useEffect(() => {
-        if (themeRef.current !== theme) {
-          themes.push(theme);
-        }
-        themeRef.current = theme;
-      }, [theme]);
-
       return (
-        <span ref={ref}>
-          {theme.foo}
-          {theme.bar}
-        </span>
+        <RenderCounter ref={getRenderCountRef}>
+          <span ref={ref}>
+            {theme.foo}
+            {theme.bar}
+          </span>
+        </RenderCounter>
       );
     }
 
@@ -88,7 +81,7 @@ describe('ThemeProvider', () => {
     expect(text()).to.equal('foobar');
     setProps({});
     expect(text()).to.equal('foobar');
-    expect(themes).to.have.length(1);
+    expect(getRenderCountRef.current()).to.equal(2);
   });
 
   describe('warnings', () => {

--- a/packages/material-ui-private-theming/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-private-theming/src/ThemeProvider/ThemeProvider.test.js
@@ -55,9 +55,13 @@ describe('ThemeProvider', () => {
     const text = () => ref.current.textContent;
     function Test() {
       const theme = useTheme();
+      const themeRef = React.useRef(); // needed due to double-invokes effect in StrictMode
       React.useEffect(() => {
-        themes.push(theme);
-      });
+        if (themeRef.current !== theme) {
+          themes.push(theme);
+        }
+        themeRef.current = theme;
+      }, [theme]);
 
       return (
         <span ref={ref}>
@@ -66,7 +70,6 @@ describe('ThemeProvider', () => {
         </span>
       );
     }
-    const MemoTest = React.memo(Test);
 
     const outerTheme = { bar: 'bar' };
     const innerTheme = { foo: 'foo' };
@@ -75,7 +78,7 @@ describe('ThemeProvider', () => {
       return (
         <ThemeProvider theme={outerTheme}>
           <ThemeProvider theme={innerTheme}>
-            <MemoTest />
+            <Test />
           </ThemeProvider>
         </ThemeProvider>
       );

--- a/packages/material-ui-unstyled/src/Portal/Portal.test.js
+++ b/packages/material-ui-unstyled/src/Portal/Portal.test.js
@@ -193,9 +193,13 @@ describe('<Portal />', () => {
 
     function Test(props) {
       const { container } = props;
+      const containerRef = React.useRef();
 
       React.useEffect(() => {
-        updateFunction();
+        if (containerRef.current !== container) {
+          updateFunction();
+        }
+        containerRef.current = container;
       }, [container]);
 
       return (

--- a/packages/material-ui-utils/src/useIsFocusVisible.test.js
+++ b/packages/material-ui-utils/src/useIsFocusVisible.test.js
@@ -79,7 +79,7 @@ describe('focus-visible polyfill', () => {
       document.body.removeChild(rootElement);
     });
 
-    it('should set focus state for shadowRoot children', () => {
+    it('should set focus state for shadowRoot children', async () => {
       const buttonRef = React.createRef();
       render(
         <SimpleButton id="test-button" ref={buttonRef}>
@@ -108,7 +108,7 @@ describe('focus-visible polyfill', () => {
       }
 
       button.blur();
-      focusVisible(button);
+      await focusVisible(button);
 
       expect(button.classList.contains('focus-visible')).to.equal(true);
     });

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { expect } from 'chai';
-import { createMount, describeConformanceV5, act, createClientRender, screen } from 'test/utils';
+import {
+  createMount,
+  describeConformanceV5,
+  createClientRender,
+  fireEvent,
+  screen,
+} from 'test/utils';
 import Breadcrumbs, { breadcrumbsClasses as classes } from '@material-ui/core/Breadcrumbs';
 
 describe('<Breadcrumbs />', () => {
@@ -68,9 +74,7 @@ describe('<Breadcrumbs />', () => {
       </Breadcrumbs>,
     );
 
-    act(() => {
-      getByRole('button').click();
-    });
+    fireEvent.click(getByRole('button'));
 
     expect(document.activeElement).to.equal(getByText('first'));
     expect(getAllByRole('listitem', { hidden: false })).to.have.length(9);

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -316,7 +316,7 @@ describe('<Button />', () => {
     expect(button).to.have.class(classes.disableElevation);
   });
 
-  it('should have a focusRipple by default', () => {
+  it('should have a focusRipple by default', async () => {
     const { getByRole } = render(
       <Button TouchRippleProps={{ classes: { ripplePulsate: 'pulsate-focus-visible' } }}>
         Hello World
@@ -324,8 +324,8 @@ describe('<Button />', () => {
     );
     const button = getByRole('button');
 
-    act(() => {
-      fireEvent.keyDown(document.body, { key: 'TAB' });
+    fireEvent.keyDown(document.body, { key: 'TAB' });
+    await act(async () => {
       button.focus();
     });
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -558,7 +558,7 @@ describe('<ButtonBase />', () => {
   });
 
   describe('focusRipple', () => {
-    it('should pulsate the ripple when focusVisible', () => {
+    it('should pulsate the ripple when focusVisible', async () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
@@ -572,7 +572,9 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       simulatePointerDevice();
-      focusVisible(button);
+      await act(async () => {
+        focusVisible(button);
+      });
 
       expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
     });
@@ -597,7 +599,7 @@ describe('<ButtonBase />', () => {
       expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
     });
 
-    it('should stop pulsate and start a ripple when the space button is pressed', () => {
+    it('should stop pulsate and start a ripple when the space button is pressed', async () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
@@ -613,14 +615,16 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       simulatePointerDevice();
-      focusVisible(button);
+      await act(async () => {
+        focusVisible(button);
+      });
       fireEvent.keyDown(button, { key: ' ' });
 
       expect(button.querySelectorAll('.ripple-pulsate .child-leaving')).to.have.lengthOf(1);
       expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(0);
     });
 
-    it('should stop and re-pulsate when space bar is released', () => {
+    it('should stop and re-pulsate when space bar is released', async () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
@@ -636,7 +640,9 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       simulatePointerDevice();
-      focusVisible(button);
+      await act(async () => {
+        focusVisible(button);
+      });
       fireEvent.keyDown(button, { key: ' ' });
       fireEvent.keyUp(button, { key: ' ' });
 
@@ -645,7 +651,7 @@ describe('<ButtonBase />', () => {
       expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(3);
     });
 
-    it('should stop on blur and set focusVisible to false', () => {
+    it('should stop on blur and set focusVisible to false', async () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
@@ -659,11 +665,14 @@ describe('<ButtonBase />', () => {
       );
       const button = getByRole('button');
       simulatePointerDevice();
-      focusVisible(button);
+      await act(async () => {
+        focusVisible(button);
+      });
 
       act(() => {
         button.blur();
       });
+      await null;
 
       expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(1);
     });
@@ -684,12 +693,14 @@ describe('<ButtonBase />', () => {
       expect(getByText('Hello')).to.have.property('disabled', true);
     });
 
-    it('should reset the focused state', () => {
+    it('should reset the focused state', async () => {
       const { getByText, setProps } = render(<ButtonBase>Hello</ButtonBase>);
       const button = getByText('Hello');
       simulatePointerDevice();
 
-      focusVisible(button);
+      await act(async () => {
+        focusVisible(button);
+      });
 
       expect(button).to.have.class(classes.focusVisible);
 
@@ -752,7 +763,7 @@ describe('<ButtonBase />', () => {
       expect(onFocusSpy.callCount).to.equal(1);
     });
 
-    it('has a focus-visible polyfill', () => {
+    it('has a focus-visible polyfill', async () => {
       const { getByText } = render(<ButtonBase>Hello</ButtonBase>);
       const button = getByText('Hello');
       simulatePointerDevice();
@@ -767,7 +778,9 @@ describe('<ButtonBase />', () => {
         expect(button).not.to.have.class(classes.focusVisible);
       }
 
-      focusVisible(button);
+      await act(async () => {
+        focusVisible(button);
+      });
 
       expect(button).to.have.class(classes.focusVisible);
     });
@@ -1082,7 +1095,7 @@ describe('<ButtonBase />', () => {
   });
 
   describe('prop: action', () => {
-    it('should be able to focus visible the button', () => {
+    it('should be able to focus visible the button', async () => {
       /**
        * @type {React.RefObject<import('./ButtonBase').ButtonBaseActions>}
        */
@@ -1100,6 +1113,7 @@ describe('<ButtonBase />', () => {
         // @ts-ignore
         buttonActionsRef.current.focusVisible();
       });
+      await null;
 
       expect(getByText('Hello')).toHaveFocus();
       expect(getByText('Hello')).to.match('.focusVisible');

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -237,7 +237,7 @@ describe('<ButtonBase />', () => {
 
   describe('ripple', () => {
     describe('interactions', () => {
-      it('should not have a focus ripple by default', () => {
+      it('should not have a focus ripple by default', async () => {
         const { getByRole } = render(
           <ButtonBase
             TouchRippleProps={{
@@ -250,7 +250,7 @@ describe('<ButtonBase />', () => {
         const button = getByRole('button');
         simulatePointerDevice();
 
-        focusVisible(button);
+        await focusVisible(button);
 
         expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(0);
       });
@@ -572,14 +572,12 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       simulatePointerDevice();
-      await act(async () => {
-        focusVisible(button);
-      });
+      await focusVisible(button);
 
       expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
     });
 
-    it('should not stop the ripple when the mouse leaves', () => {
+    it('should not stop the ripple when the mouse leaves', async () => {
       const { getByRole } = render(
         <ButtonBase
           focusRipple
@@ -593,7 +591,7 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       simulatePointerDevice();
-      focusVisible(button);
+      await focusVisible(button);
       fireEvent.mouseLeave(button);
 
       expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
@@ -615,9 +613,7 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       simulatePointerDevice();
-      await act(async () => {
-        focusVisible(button);
-      });
+      await focusVisible(button);
       fireEvent.keyDown(button, { key: ' ' });
 
       expect(button.querySelectorAll('.ripple-pulsate .child-leaving')).to.have.lengthOf(1);
@@ -640,9 +636,7 @@ describe('<ButtonBase />', () => {
       const button = getByRole('button');
 
       simulatePointerDevice();
-      await act(async () => {
-        focusVisible(button);
-      });
+      await focusVisible(button);
       fireEvent.keyDown(button, { key: ' ' });
       fireEvent.keyUp(button, { key: ' ' });
 
@@ -665,9 +659,7 @@ describe('<ButtonBase />', () => {
       );
       const button = getByRole('button');
       simulatePointerDevice();
-      await act(async () => {
-        focusVisible(button);
-      });
+      await focusVisible(button);
 
       act(() => {
         button.blur();
@@ -698,9 +690,7 @@ describe('<ButtonBase />', () => {
       const button = getByText('Hello');
       simulatePointerDevice();
 
-      await act(async () => {
-        focusVisible(button);
-      });
+      await focusVisible(button);
 
       expect(button).to.have.class(classes.focusVisible);
 
@@ -778,14 +768,12 @@ describe('<ButtonBase />', () => {
         expect(button).not.to.have.class(classes.focusVisible);
       }
 
-      await act(async () => {
-        focusVisible(button);
-      });
+      await focusVisible(button);
 
       expect(button).to.have.class(classes.focusVisible);
     });
 
-    it('removes foucs-visible if focus is re-targetted', () => {
+    it('removes foucs-visible if focus is re-targetted', async () => {
       /**
        * @type {string[]}
        */
@@ -823,14 +811,14 @@ describe('<ButtonBase />', () => {
       const focusRetarget = getByText('you cannot escape me');
       simulatePointerDevice();
 
-      focusVisible(buttonBase);
+      await focusVisible(buttonBase);
 
       expect(focusRetarget).toHaveFocus();
       expect(eventLog).to.deep.equal(['focus-visible', 'focus', 'blur']);
       expect(buttonBase).not.to.have.class(classes.focusVisible);
     });
 
-    it('onFocusVisibleHandler() should propagate call to onFocusVisible prop', () => {
+    it('onFocusVisibleHandler() should propagate call to onFocusVisible prop', async () => {
       const onFocusVisibleSpy = spy();
       const { getByRole } = render(
         <ButtonBase component="span" onFocusVisible={onFocusVisibleSpy}>
@@ -839,7 +827,7 @@ describe('<ButtonBase />', () => {
       );
       simulatePointerDevice();
 
-      focusVisible(getByRole('button'));
+      await focusVisible(getByRole('button'));
 
       expect(onFocusVisibleSpy.calledOnce).to.equal(true);
       expect(onFocusVisibleSpy.firstCall.args).to.have.lengthOf(1);

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -549,7 +549,7 @@ describe('<Chip />', () => {
   });
 
   describe('event: focus', () => {
-    it('has a focus-visible polyfill', () => {
+    it('has a focus-visible polyfill', async () => {
       const { container } = render(<Chip label="Test Chip" onClick={() => {}} />);
       const chip = container.querySelector(`.${classes.root}`);
       simulatePointerDevice();
@@ -564,17 +564,21 @@ describe('<Chip />', () => {
         expect(chip).not.to.have.class(classes.focusVisible);
       }
 
-      focusVisible(chip);
+      await act(async () => {
+        focusVisible(chip);
+      });
 
       expect(chip).to.have.class(classes.focusVisible);
     });
 
-    it('should reset the focused state', () => {
+    it('should reset the focused state', async () => {
       const { container, setProps } = render(<Chip label="Test Chip" onClick={() => {}} />);
       const chip = container.querySelector(`.${classes.root}`);
 
       simulatePointerDevice();
-      focusVisible(chip);
+      await act(async () => {
+        focusVisible(chip);
+      });
 
       expect(chip).to.have.class(classes.focusVisible);
 

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -564,9 +564,7 @@ describe('<Chip />', () => {
         expect(chip).not.to.have.class(classes.focusVisible);
       }
 
-      await act(async () => {
-        focusVisible(chip);
-      });
+      await focusVisible(chip);
 
       expect(chip).to.have.class(classes.focusVisible);
     });
@@ -576,9 +574,7 @@ describe('<Chip />', () => {
       const chip = container.querySelector(`.${classes.root}`);
 
       simulatePointerDevice();
-      await act(async () => {
-        focusVisible(chip);
-      });
+      await focusVisible(chip);
 
       expect(chip).to.have.class(classes.focusVisible);
 

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -165,7 +165,7 @@ describe('<ClickAwayListener />', () => {
     });
 
     ['onClick', 'onClickCapture'].forEach((eventListenerName) => {
-      it(`should not be called when ${eventListenerName} mounted the listener`, () => {
+      it(`should not be called when ${eventListenerName} mounted the listener`, async () => {
         function Test() {
           const [open, setOpen] = React.useState(false);
 
@@ -186,12 +186,13 @@ describe('<ClickAwayListener />', () => {
         render(<Test />);
 
         fireDiscreteEvent.click(screen.getByTestId('trigger'));
+        await null;
 
         expect(screen.getByTestId('child')).not.to.equal(null);
       });
     });
 
-    it('should be called if an element is interleaved between mousedown and mouseup', () => {
+    it('should be called if an element is interleaved between mousedown and mouseup', async () => {
       /**
        * @param {Element} element
        * @returns {Element[]}
@@ -250,6 +251,7 @@ describe('<ClickAwayListener />', () => {
       const mouseDownTarget = screen.getByTestId('trigger');
 
       fireDiscreteEvent.mouseDown(mouseDownTarget);
+      await null;
       const mouseUpTarget = screen.getByTestId('interleaved-element');
       // https://w3c.github.io/uievents/#events-mouseevent-event-order
       const clickTarget = findNearestCommonAncestor(mouseDownTarget, mouseUpTarget);

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -113,8 +113,9 @@ describe('<Fab />', () => {
     );
     const button = getByRole('button');
 
-    act(() => {
-      fireEvent.keyDown(document.body, { key: 'TAB' });
+    fireEvent.keyDown(document.body, { key: 'TAB' });
+
+    await act(async () => {
       button.focus();
     });
 

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -135,8 +135,9 @@ describe('<Fab />', () => {
     );
     const button = getByRole('button');
 
-    act(() => {
-      fireEvent.keyDown(document.body, { key: 'TAB' });
+    fireEvent.keyDown(document.body, { key: 'TAB' });
+
+    await act(async () => {
       button.focus();
     });
 

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -85,7 +85,7 @@ describe('<FormControl />', () => {
   });
 
   describe('prop: disabled', () => {
-    it('will be unfocused if it gets disabled', () => {
+    it('will be unfocused if it gets disabled', async () => {
       const readContext = spy();
       const { container, setProps } = render(
         <FormControl>
@@ -95,13 +95,13 @@ describe('<FormControl />', () => {
       );
       expect(readContext.args[0][0]).to.have.property('focused', false);
 
-      act(() => {
+      await act(() => {
         container.querySelector('input').focus();
       });
-      expect(readContext.args[1][0]).to.have.property('focused', true);
+      expect(readContext.lastCall.args[0]).to.have.property('focused', true);
 
       setProps({ disabled: true });
-      expect(readContext.args[2][0]).to.have.property('focused', false);
+      expect(readContext.lastCall.args[0]).to.have.property('focused', false);
     });
   });
 

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -62,14 +62,14 @@ describe('<InputBase />', () => {
       expect(input).to.have.class(classes.disabled);
     });
 
-    it('should reset the focused state if getting disabled', () => {
+    it('should reset the focused state if getting disabled', async () => {
       const handleBlur = spy();
       const handleFocus = spy();
       const { container, setProps } = render(
         <InputBase onBlur={handleBlur} onFocus={handleFocus} />,
       );
 
-      act(() => {
+      await act(() => {
         container.querySelector('input').focus();
       });
       expect(handleFocus.callCount).to.equal(1);
@@ -362,7 +362,7 @@ describe('<InputBase />', () => {
     });
 
     describe('focused', () => {
-      it('prioritizes context focus', () => {
+      it('prioritizes context focus', async () => {
         const FormController = React.forwardRef((props, ref) => {
           const { onBlur, onFocus } = useFormControl();
 
@@ -378,7 +378,7 @@ describe('<InputBase />', () => {
           </FormControl>,
         );
 
-        act(() => {
+        await act(() => {
           getByRole('textbox').focus();
         });
         expect(getByTestId('root')).to.have.class(classes.focused);
@@ -396,7 +396,7 @@ describe('<InputBase />', () => {
         expect(getByTestId('root')).to.have.class(classes.focused);
       });
 
-      it('propagates focused state', () => {
+      it('propagates focused state', async () => {
         function FocusedStateLabel(props) {
           const { focused } = useFormControl();
           return <label {...props}>focused: {String(focused)}</label>;
@@ -409,12 +409,12 @@ describe('<InputBase />', () => {
         );
         expect(getByTestId('label')).to.have.text('focused: false');
 
-        act(() => {
+        await act(() => {
           getByRole('textbox').focus();
         });
         expect(getByTestId('label')).to.have.text('focused: true');
 
-        act(() => {
+        await act(() => {
           getByRole('textbox').blur();
         });
         expect(getByTestId('label')).to.have.text('focused: false');

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -83,7 +83,7 @@ describe('<InputLabel />', () => {
     });
 
     describe('focused', () => {
-      it('applies a shrink class that can be controlled by props', () => {
+      it('applies a shrink class that can be controlled by props', async () => {
         function Wrapper({ children }) {
           return (
             <FormControl>
@@ -97,7 +97,7 @@ describe('<InputLabel />', () => {
         const { container, getByTestId, setProps } = render(<InputLabel data-testid="root" />, {
           wrapper: Wrapper,
         });
-        act(() => {
+        await act(() => {
           container.querySelector('input').focus();
         });
 

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -5,8 +5,8 @@ import { createMount, act, createClientRender, fireEvent, describeConformanceV5 
 import Link, { linkClasses as classes } from '@material-ui/core/Link';
 import Typography, { typographyClasses } from '@material-ui/core/Typography';
 
-function focusVisible(element) {
-  act(() => {
+async function focusVisible(element) {
+  await act(async () => {
     element.blur();
     document.dispatchEvent(new window.Event('keydown'));
     element.focus();
@@ -70,19 +70,20 @@ describe('<Link />', () => {
   });
 
   describe('keyboard focus', () => {
-    it('should add the focusVisible class when focused', () => {
+    it('should add the focusVisible class when focused', async () => {
       const { container } = render(<Link href="/">Home</Link>);
       const anchor = container.querySelector('a');
 
       expect(anchor).not.to.have.class(classes.focusVisible);
 
-      focusVisible(anchor);
+      await focusVisible(anchor);
 
       expect(anchor).to.have.class(classes.focusVisible);
 
       act(() => {
         anchor.blur();
       });
+      await null;
 
       expect(anchor).not.to.have.class(classes.focusVisible);
     });

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -201,14 +201,15 @@ describe('<ListItem />', () => {
 
   // TODO remove in v6 in favor of ListItemButton
   describe('prop: focusVisibleClassName', () => {
-    it('should merge the class names', () => {
+    it('should merge the class names', async () => {
       const { getByRole } = render(
         <ListItem button focusVisibleClassName="focusVisibleClassName" />,
       );
       const button = getByRole('button');
 
-      act(() => {
-        fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
+      fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
+
+      await act(async () => {
         button.focus();
       });
 

--- a/packages/material-ui/src/ListItemButton/ListItemButton.test.js
+++ b/packages/material-ui/src/ListItemButton/ListItemButton.test.js
@@ -53,14 +53,15 @@ describe('<ListItemButton />', () => {
   });
 
   describe('prop: focusVisibleClassName', () => {
-    it('should merge the class names', () => {
+    it('should merge the class names', async () => {
       const { getByRole } = render(
         <ListItemButton focusVisibleClassName="focusVisibleClassName" />,
       );
       const button = getByRole('button');
 
-      act(() => {
-        fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
+      fireEvent.keyDown(document.activeElement || document.body, { key: 'Tab' });
+
+      await act(async () => {
         button.focus();
       });
 

--- a/packages/material-ui/src/Rating/Rating.test.js
+++ b/packages/material-ui/src/Rating/Rating.test.js
@@ -110,14 +110,14 @@ describe('<Rating />', () => {
     expect(checked.value).to.equal('2');
   });
 
-  it('has a customization point for the label of the empty value when it is active', () => {
+  it('has a customization point for the label of the empty value when it is active', async () => {
     const { container } = render(
       <Rating classes={{ labelEmptyValueActive: 'customized' }} name="" value={null} />,
     );
 
     expect(container.querySelector('.customized')).to.equal(null);
 
-    act(() => {
+    await act(() => {
       const noValueRadio = screen.getAllByRole('radio').find((radio) => {
         return radio.checked;
       });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -92,7 +92,7 @@ describe('<Select />', () => {
     expect(container.querySelector('input')).to.have.attribute('aria-hidden', 'true');
   });
 
-  it('should ignore onBlur when the menu opens', () => {
+  it('should ignore onBlur when the menu opens', async () => {
     // mousedown calls focus while click opens moving the focus to an item
     // this means the trigger is blurred immediately
     const handleBlur = spy();
@@ -118,9 +118,10 @@ describe('<Select />', () => {
     expect(handleBlur.callCount).to.equal(0);
     expect(getByRole('listbox')).not.to.equal(null);
 
-    act(() => {
-      const options = getAllByRole('option');
-      fireEvent.mouseDown(options[0]);
+    const options = getAllByRole('option');
+    fireEvent.mouseDown(options[0]);
+
+    await act(() => {
       options[0].click();
     });
 
@@ -725,9 +726,7 @@ describe('<Select />', () => {
       fireEvent.mouseDown(getByRole('button'));
       expect(getByRole('listbox')).not.to.equal(null);
 
-      act(() => {
-        getByRole('option').click();
-      });
+      fireEvent.click(getByRole('option'));
       // react-transition-group uses one extra commit for exit to completely remove
       // it from the DOM. but it's at least immediately inaccessible.
       // It's desired that this fails one day. The additional tick required to remove

--- a/packages/material-ui/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui/src/SpeedDial/SpeedDial.test.js
@@ -215,7 +215,7 @@ describe('<SpeedDial />', () => {
       expect(fab).to.have.attribute('aria-expanded', 'true');
     });
 
-    it('should reset the state of the tooltip when the speed dial is closed while it is open', () => {
+    it('should reset the state of the tooltip when the speed dial is closed while it is open', async () => {
       const handleOpen = spy();
       const { queryByRole, getByRole, getAllByRole } = render(
         <SpeedDial ariaLabel="mySpeedDial" onOpen={handleOpen}>
@@ -226,7 +226,9 @@ describe('<SpeedDial />', () => {
       const fab = getByRole('button');
       const actions = getAllByRole('menuitem');
 
-      fab.focus();
+      await act(() => {
+        fab.focus();
+      });
       act(() => {
         clock.runAll();
       });
@@ -240,6 +242,7 @@ describe('<SpeedDial />', () => {
       expect(queryByRole('tooltip')).not.to.equal(null);
 
       fireDiscreteEvent.keyDown(actions[0], { key: 'Escape' });
+      await null;
       act(() => {
         clock.runAll();
       });

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -35,15 +35,16 @@ describe('<Tab />', () => {
     expect(container.querySelector('.touch-ripple')).to.equal(null);
   });
 
-  it('should have a focusRipple by default', () => {
+  it('should have a focusRipple by default', async () => {
     const { container, getByRole } = render(
       <Tab TouchRippleProps={{ classes: { ripplePulsate: 'focus-ripple' } }} />,
     );
     // simulate pointer device
     fireEvent.pointerDown(document.body);
 
-    act(() => {
-      fireEvent.keyDown(document.body, { key: 'Tab' });
+    fireEvent.keyDown(document.body, { key: 'Tab' });
+
+    await act(async () => {
       // jsdom doesn't actually support tab focus, we need to do it manually
       getByRole('tab').focus();
     });

--- a/packages/material-ui/src/Tabs/ScrollbarSize.test.js
+++ b/packages/material-ui/src/Tabs/ScrollbarSize.test.js
@@ -22,7 +22,7 @@ describe('<ScrollbarSize />', () => {
       const onChange = spy();
       render(<ScrollbarSize onChange={onChange} />);
 
-      expect(onChange.callCount).to.equal(1);
+      expect(onChange.called).to.equal(true);
     });
   });
 
@@ -33,11 +33,12 @@ describe('<ScrollbarSize />', () => {
       stub(container.firstChild, 'offsetHeight').get(() => 20);
       stub(container.firstChild, 'clientHeight').get(() => 0);
 
-      expect(onChange.callCount).to.equal(1);
+      onChange.resetHistory();
+
       window.dispatchEvent(new window.Event('resize', {}));
       clock.tick(166);
-      expect(onChange.callCount).to.equal(2);
-      expect(onChange.args[1][0]).to.equal(20);
+      expect(onChange.callCount).to.equal(1);
+      expect(onChange.args[0][0]).to.equal(20);
     });
 
     it('should not call if height has not changed from previous resize', () => {
@@ -46,13 +47,14 @@ describe('<ScrollbarSize />', () => {
       stub(container.firstChild, 'offsetHeight').get(() => 20);
       stub(container.firstChild, 'clientHeight').get(() => 0);
 
+      onChange.resetHistory();
+
+      window.dispatchEvent(new window.Event('resize', {}));
+      clock.tick(166);
+      window.dispatchEvent(new window.Event('resize', {}));
+      clock.tick(166);
       expect(onChange.callCount).to.equal(1);
-      window.dispatchEvent(new window.Event('resize', {}));
-      clock.tick(166);
-      window.dispatchEvent(new window.Event('resize', {}));
-      clock.tick(166);
-      expect(onChange.callCount).to.equal(2);
-      expect(onChange.args[1][0]).to.equal(20);
+      expect(onChange.args[0][0]).to.equal(20);
     });
   });
 });

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -149,7 +149,7 @@ describe('<SwitchBase />', () => {
     });
   });
 
-  it('can change checked state uncontrolled starting from defaultChecked', () => {
+  it('can change checked state uncontrolled starting from defaultChecked', async () => {
     const { container, getByRole, getByTestId } = render(
       <SwitchBase
         icon={<span data-testid="unchecked-icon" />}
@@ -164,7 +164,7 @@ describe('<SwitchBase />', () => {
     expect(checkbox).to.have.property('checked', true);
     expect(getByTestId('checked-icon')).not.to.equal(null);
 
-    act(() => {
+    await act(() => {
       checkbox.click();
     });
 
@@ -172,7 +172,7 @@ describe('<SwitchBase />', () => {
     expect(checkbox).to.have.property('checked', false);
     expect(getByTestId('unchecked-icon')).not.to.equal(null);
 
-    act(() => {
+    await act(() => {
       checkbox.click();
     });
 
@@ -201,7 +201,7 @@ describe('<SwitchBase />', () => {
       expect(handleChange.firstCall.args[0].target).to.have.property('checked', true);
     });
 
-    it('should call onChange when controlled', () => {
+    it('should call onChange when controlled', async () => {
       const defaultChecked = true;
       function ControlledSwichBase() {
         const [checked, setChecked] = React.useState(defaultChecked);
@@ -220,7 +220,7 @@ describe('<SwitchBase />', () => {
       const { getByRole } = render(<ControlledSwichBase />);
       const checkbox = getByRole('checkbox');
 
-      act(() => {
+      await act(() => {
         checkbox.click();
       });
 
@@ -351,7 +351,7 @@ describe('<SwitchBase />', () => {
   });
 
   describe('focus/blur', () => {
-    it('forwards focus/blur events and notifies the FormControl', () => {
+    it('forwards focus/blur events and notifies the FormControl', async () => {
       function FocusMonitor(props) {
         const { focused } = useFormControl();
 
@@ -373,14 +373,14 @@ describe('<SwitchBase />', () => {
       );
       const checkbox = getByRole('checkbox');
 
-      act(() => {
+      await act(() => {
         checkbox.focus();
       });
 
       expect(getByTestId('focus-monitor')).to.have.text('focused: true');
       expect(handleFocus.callCount).to.equal(1);
 
-      act(() => {
+      await act(() => {
         checkbox.blur();
       });
 

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -96,11 +96,11 @@ describe('<Menu /> integration', () => {
     expect(getByRole('menu', { hidden: true })).not.to.contain(document.activeElement);
   });
 
-  it('should focus the first item on open', () => {
+  it('should focus the first item on open', async () => {
     const { getByRole, getAllByRole } = render(<ButtonMenu />);
 
     const button = getByRole('button', { name: 'open menu' });
-    act(() => {
+    await act(() => {
       button.focus();
       button.click();
     });
@@ -108,11 +108,11 @@ describe('<Menu /> integration', () => {
     expect(getAllByRole('menuitem')[0]).toHaveFocus();
   });
 
-  it('changes focus according to keyboard navigation', () => {
+  it('changes focus according to keyboard navigation', async () => {
     const { getAllByRole, getByRole } = render(<ButtonMenu />);
 
     const button = getByRole('button', { name: 'open menu' });
-    act(() => {
+    await act(() => {
       button.focus();
       button.click();
     });
@@ -137,11 +137,11 @@ describe('<Menu /> integration', () => {
     expect(menuitems[2], 'no change on unassociated keys').toHaveFocus();
   });
 
-  it('focuses the selected item when opening', () => {
+  it('focuses the selected item when opening', async () => {
     const { getAllByRole, getByRole } = render(<ButtonMenu selectedIndex={2} />);
 
     const button = getByRole('button', { name: 'open menu' });
-    act(() => {
+    await act(() => {
       button.focus();
       button.click();
     });
@@ -302,12 +302,12 @@ describe('<Menu /> integration', () => {
 
     specify(
       '[variant=selectedMenu] focuses the selected item when opening when it was already mounted',
-      () => {
+      async () => {
         const { getAllByRole, getByRole } = render(
           <ButtonMenu selectedIndex={1} variant="selectedMenu" />,
         );
 
-        act(() => {
+        await act(() => {
           getByRole('button').focus();
           getByRole('button').click();
         });
@@ -321,11 +321,11 @@ describe('<Menu /> integration', () => {
     );
   });
 
-  it('closes the menu when Tabbing while the list is active', () => {
+  it('closes the menu when Tabbing while the list is active', async () => {
     render(<ButtonMenu />);
 
     const trigger = screen.getByRole('button');
-    act(() => {
+    await act(() => {
       trigger.focus();
       trigger.click();
     });

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -51,7 +51,7 @@ describe('<Select> integration', () => {
       clock.restore();
     });
 
-    it('should focus the selected item', () => {
+    it('should focus the selected item', async () => {
       const { getByTestId, getAllByRole, getByRole, queryByRole } = render(<SelectAndDialog />);
 
       const trigger = getByRole('button');
@@ -63,9 +63,7 @@ describe('<Select> integration', () => {
       expect(options[1]).toHaveFocus();
 
       // Now, let's close the select component
-      act(() => {
-        getByTestId('select-backdrop').click();
-      });
+      fireEvent.click(getByTestId('select-backdrop'));
       act(() => {
         clock.tick(0);
       });
@@ -74,7 +72,7 @@ describe('<Select> integration', () => {
       expect(trigger).toHaveFocus();
     });
 
-    it('should be able to change the selected item', () => {
+    it('should be able to change the selected item', async () => {
       const { getAllByRole, getByRole, queryByRole } = render(<SelectAndDialog />);
 
       const trigger = getByRole('button');
@@ -87,9 +85,7 @@ describe('<Select> integration', () => {
       expect(options[1]).toHaveFocus();
 
       // Now, let's close the select component
-      act(() => {
-        options[2].click();
-      });
+      fireEvent.click(options[2]);
       act(() => {
         clock.tick(0);
       });
@@ -143,7 +139,7 @@ describe('<Select> integration', () => {
       expect(getByTestId('label')).to.have.class('focused-label');
     });
 
-    it('does not stays in an active state if an open action did not actually open', () => {
+    it('does not stays in an active state if an open action did not actually open', async () => {
       // test for https://github.com/mui-org/material-ui/issues/17294
       // we used to set a flag to stop blur propagation when we wanted to open the
       // select but never considered what happened if the select never opened
@@ -160,7 +156,7 @@ describe('<Select> integration', () => {
       );
       const trigger = getByRole('button');
 
-      act(() => {
+      await act(() => {
         trigger.focus();
       });
 
@@ -170,7 +166,7 @@ describe('<Select> integration', () => {
 
       expect(container.querySelector('[for="age-simple"]')).to.have.class('focused-label');
 
-      act(() => {
+      await act(() => {
         trigger.blur();
       });
 

--- a/test/utils/focusVisible.ts
+++ b/test/utils/focusVisible.ts
@@ -1,7 +1,7 @@
 import { act, fireEvent } from './createClientRender';
 
-export default function focusVisible(element: HTMLElement) {
-  act(() => {
+export default async function focusVisible(element: HTMLElement) {
+  await act(async () => {
     element.blur();
     fireEvent.keyDown(document.body, { key: 'Tab' });
     element.focus();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

**strict effects related**
I follow the last approach in https://github.com/reactwg/react-18/discussions/17
- ThemeProvider
- Portal

**focus related**
As far as I debug, the setState is called but I guess it is async so I wrap it like this
```js
await act(async() => {
  element.focus() // or focusVisible(element)
})

// using await null; does not work
```
- ButtonBase
- Button
- ListItemButton
- Tab
- Fab
- Chip

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
